### PR TITLE
Handle unknown turn types

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,14 @@ module.exports = function(_version) {
             if (!instructions[version]) { throw new Error('Invalid version'); }
             if (!type) { throw new Error('Missing step maneuver type'); }
             if (!modifier) { throw new Error('Missing step maneuver modifier'); }
-            if (!instructions[version][type]) throw new Error('Unknown type', type);
             if (!step.maneuver.modifier) throw new Error('No maneuver provided');
+
+            if (!instructions[version][type]) {
+                // osrm specification assumes turn types can be added without
+                // major voersion changes and unknown types are treated
+                // as type `turn` by clients
+                type = 'turn';
+            }
 
             // First check if the modifier for this maneuver has a special instruction
             // If not, use the `defaultInstruction`

--- a/test/fixtures/v5/unkown_left.json
+++ b/test/fixtures/v5/unkown_left.json
@@ -1,0 +1,11 @@
+{
+    "step": {
+        "name": "Street Name",
+        "maneuver": {
+            "type": "deliberatly_unknown_type",
+            "modifier": "left"
+        }
+    },
+    "instruction": "Turn left onto Street Name",
+    "testName": "unknown types are treated as turns"
+}


### PR DESCRIPTION
> new identifiers might be introduced without API change Types unknown to the client should be handled like the turn type, the existance of correct modifier values is guranteed.

https://github.com/Project-OSRM/osrm-backend/blob/master/docs/http.md#properties-4

/cc @bsudekum 